### PR TITLE
feat: add mkdocs and terraformdocs renovate configuration

### DIFF
--- a/custom/mkdocs.json
+++ b/custom/mkdocs.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["Makefile"],
+      "matchStrings": [
+        "MKDOCS_IMAGE_TAG[\\ \\?:]*=[\\ ]*(?<currentValue>.*?)\n"
+      ],
+      "depNameTemplate": "mkdocs_makefile",
+      "versioningTemplate": "semver-coerced",
+      "datasourceTemplate": "custom.mkdocs_makefile"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["Makefile"],
+      "matchStrings": [
+        "BITNAMI_NGINX_IMAGE_TAG[\\ \\?:]*=[\\ ]*(?<currentValue>.*?)\n"
+      ],
+      "depNameTemplate": "bitnami_nginx_makefile",
+      "versioningTemplate": "semver-coerced",
+      "datasourceTemplate": "custom.bitnami_nginx_makefile"
+    }
+  ],
+  "customDatasources": {
+    "mkdocs_makefile": {
+      "defaultRegistryUrlTemplate": "https://hub.docker.com/v2/namespaces/squidfunk/repositories/mkdocs-material/tags",
+      "transformTemplates": [
+        "{ \"releases\": $map($.results, function($v) { { \"version\": $v.name } }) }"
+      ]
+    },
+    "bitnami_nginx_makefile": {
+      "defaultRegistryUrlTemplate": "https://hub.docker.com/v2/namespaces/bitnami/repositories/nginx/tags",
+      "transformTemplates": [
+        "{ \"releases\": $map($.results, function($v) { { \"version\": $v.name } }) }"
+      ]
+    }
+  }
+}

--- a/custom/terraform_docs.json
+++ b/custom/terraform_docs.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["Makefile"],
+      "matchStrings": [
+        "TERRAFORM_DOCS_IMAGE_TAG[\\ \\?:]*=[\\ ]*(?<currentValue>.*?)\n"
+      ],
+      "depNameTemplate": "terraform_docs_makefile",
+      "versioningTemplate": "semver-coerced",
+      "datasourceTemplate": "custom.terraform_docs_makefile"
+    }
+  ],
+  "customDatasources": {
+    "terraform_docs_makefile": {
+      "defaultRegistryUrlTemplate": "https://quay.io/api/v1/repository/terraform-docs/terraform-docs/tag/",
+      "transformTemplates": [
+        "{ \"releases\": $map($.tags, function($v) { { \"version\": $v.name } }) }"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added custom Renovate configurations to automatically manage version updates for:
  - MkDocs Material Docker image in Makefile (DEV_IMAGE_TAG)
  - Bitnami Nginx Docker image in Makefile (DIST_BASE_IMAGE_TAG)
  - terraform-docs version in Makefile (TERRAFORM_DOCS_VERSION)
- Implemented regex-based version detection in Makefiles
- Set up custom datasources to fetch latest versions from Docker Hub and Quay.io registries
- Added proper schema validation using Renovate JSON schema



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mkdocs.json</strong><dd><code>Configure Renovate for MkDocs and Nginx Docker images</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom/mkdocs.json

<li>Added custom Renovate configuration for managing Docker image versions <br>in Makefile<br> <li> Configured regex matching for mkdocs-material and nginx image tags<br> <li> Set up custom datasources to fetch versions from Docker Hub registries<br> <br>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/renovatebot-default-configuration/pull/6/files#diff-254e5f8894dacf2ea82ea29c2bc509ea76fdb8e06e52cb41f2d1146f672b7a67">+35/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>terraform_docs.json</strong><dd><code>Configure Renovate for terraform-docs version management</code>&nbsp; </dd></summary>
<hr>

custom/terraform_docs.json

<li>Added custom Renovate configuration for terraform-docs version in <br>Makefile<br> <li> Set up regex matching for TERRAFORM_DOCS_VERSION variable<br> <li> Configured custom datasource to fetch versions from Quay.io registry<br>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/renovatebot-default-configuration/pull/6/files#diff-aae8468498ec3f270d89c4a8dce09187a1e562976196419f7f1a53208a3367d9">+21/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information