### PR TITLE
fix: change config:base to config:recommended

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,15 +1,13 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
-    ":dependencyDashboard",
+    "config:recommended",
     ":rebaseStalePrs",
     ":enableVulnerabilityAlertsWithLabel('security')",
     ":semanticCommits",
     ":semanticCommitScope(deps)",
     ":disableMajorUpdates",
-    ":preserveSemverRanges",
-    "group:recommended"
+    ":preserveSemverRanges"
   ],
   "timezone": "Europe/Rome",
   "labels": ["dependencies"],


### PR DESCRIPTION
As you can see [here](https://docs.renovatebot.com/presets-config/), `config:base` is not present as Config preset.

I also removed the `:dependencyDashboard` and  `group:recommended` lines, because they are already extended in the `config:recommended` as you can see [here](https://docs.renovatebot.com/presets-config/#configrecommended).