### PR TITLE
feat: track mkdocs and zensical image tags, drop bitnami

### DIFF
--- a/custom/mkdocs.json
+++ b/custom/mkdocs.json
@@ -3,26 +3,6 @@
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": ["Makefile"],
-      "matchStrings": [
-        "MKDOCS_IMAGE_TAG[\\ \\?:]*=[\\ ]*(?<currentValue>.*?)\n"
-      ],
-      "depNameTemplate": "mkdocs",
-      "versioningTemplate": "semver-coerced",
-      "datasourceTemplate": "custom.mkdocs"
-    },
-    {
-      "customType": "regex",
-      "fileMatch": ["Makefile"],
-      "matchStrings": [
-        "BITNAMI_NGINX_IMAGE_TAG[\\ \\?:]*=[\\ ]*(?<currentValue>.*?)\n"
-      ],
-      "depNameTemplate": "bitnami_nginx",
-      "versioningTemplate": "semver-coerced",
-      "datasourceTemplate": "custom.bitnami_nginx"
-    },
-    {
-      "customType": "regex",
       "fileMatch": ["configuration_schema\\.json"],
       "matchStrings": [
         "\"MKDOCS_IMAGE_TAG\":[\\s\\S]*?\"default\":\\s*\"(?<currentValue>[^\"]+)\""
@@ -35,11 +15,31 @@
       "customType": "regex",
       "fileMatch": ["configuration_schema\\.json"],
       "matchStrings": [
-        "\"BITNAMI_NGINX_IMAGE_TAG\":[\\s\\S]*?\"default\":\\s*\"(?<currentValue>[^\"]+)\""
+        "\"ZENSICAL_IMAGE_TAG\":[\\s\\S]*?\"default\":\\s*\"(?<currentValue>[^\"]+)\""
       ],
-      "depNameTemplate": "bitnami_nginx_configuration_schema",
+      "depNameTemplate": "zensical_configuration_schema",
       "versioningTemplate": "semver-coerced",
-      "datasourceTemplate": "custom.bitnami_nginx"
+      "datasourceTemplate": "custom.zensical"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["(^|/)fs-pkg-config\\.ya?ml$"],
+      "matchStrings": [
+        "MKDOCS_IMAGE_TAG:\\s*[\"']?(?<currentValue>[^\"'\\s#]+)"
+      ],
+      "depNameTemplate": "mkdocs_fs_pkg_config",
+      "versioningTemplate": "semver-coerced",
+      "datasourceTemplate": "custom.mkdocs"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["(^|/)fs-pkg-config\\.ya?ml$"],
+      "matchStrings": [
+        "ZENSICAL_IMAGE_TAG:\\s*[\"']?(?<currentValue>[^\"'\\s#]+)"
+      ],
+      "depNameTemplate": "zensical_fs_pkg_config",
+      "versioningTemplate": "semver-coerced",
+      "datasourceTemplate": "custom.zensical"
     }
   ],
   "customDatasources": {
@@ -49,8 +49,8 @@
         "{ \"releases\": $map($.results, function($v) { { \"version\": $v.name } }) }"
       ]
     },
-    "bitnami_nginx": {
-      "defaultRegistryUrlTemplate": "https://hub.docker.com/v2/namespaces/bitnamilegacy/repositories/nginx/tags",
+    "zensical": {
+      "defaultRegistryUrlTemplate": "https://hub.docker.com/v2/namespaces/zensical/repositories/zensical/tags",
       "transformTemplates": [
         "{ \"releases\": $map($.results, function($v) { { \"version\": $v.name } }) }"
       ]


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @Monska85._

## Summary

Updates the `custom/mkdocs` preset so Renovate keeps the MkDocs and Zensical image tags current, and removes dead configuration left over from the bitnami removal.

This is the upstream half of the Zensical work in the `pkg_mkdocs` package (which adds an `ENABLE_ZENSICAL` flag and a `ZENSICAL_IMAGE_TAG`). The package side is tracked in its own merge request on GitLab.

## What changed

- **Add Zensical** alongside MkDocs: a `zensical` custom datasource (Docker Hub `zensical/zensical` tags) and managers for `ZENSICAL_IMAGE_TAG`.
- **Track two sources** for both `MKDOCS_IMAGE_TAG` and `ZENSICAL_IMAGE_TAG`:
  - `configuration_schema.json` defaults (the package repo).
  - `fs-pkg-config.yml` pins (consumer projects that override the tag). This is the durable place a consumer pins a tag, so it is the right target for consumer-side bumps.
- **Remove the bitnami managers and datasource.** The package dropped bitnami in favour of the official nginx image, so `BITNAMI_NGINX_IMAGE_TAG` no longer exists anywhere.
- **Remove the Makefile managers.** They were no-ops: on the package side they matched only the Twig placeholder `{{ MKDOCS_IMAGE_TAG }}`, and on the consumer side the rendered `Makefile` is regenerated by fs-cli on every sync, so any bump there would be overwritten.

## Note on nginx

`NGINX_IMAGE_TAG` defaults to the rolling `stable-alpine-slim` tag, which has no semver to bump, so it is intentionally left untracked.