### PR TITLE
fix(mkdocs): add releaseTimestamp to docker hub datasources

### DIFF
--- a/custom/mkdocs.json
+++ b/custom/mkdocs.json
@@ -46,13 +46,13 @@
     "mkdocs": {
       "defaultRegistryUrlTemplate": "https://hub.docker.com/v2/namespaces/squidfunk/repositories/mkdocs-material/tags",
       "transformTemplates": [
-        "{ \"releases\": $map($.results, function($v) { { \"version\": $v.name } }) }"
+        "{ \"releases\": $map($.results, function($v) { { \"version\": $v.name, \"releaseTimestamp\": $v.tag_last_pushed } }) }"
       ]
     },
     "zensical": {
       "defaultRegistryUrlTemplate": "https://hub.docker.com/v2/namespaces/zensical/repositories/zensical/tags",
       "transformTemplates": [
-        "{ \"releases\": $map($.results, function($v) { { \"version\": $v.name } }) }"
+        "{ \"releases\": $map($.results, function($v) { { \"version\": $v.name, \"releaseTimestamp\": $v.tag_last_pushed } }) }"
       ]
     }
   }


### PR DESCRIPTION
### **User description**
The mkdocs and zensical custom datasources mapped only the tag name from the Docker Hub tags API and dropped tag_last_pushed, so releases had no releaseTimestamp. With minimumReleaseAge set in default.json and Renovate's default minimumReleaseAgeBehaviour=timestamp-required, every release was marked pending forever: the image tag updates sat in the Dependency Dashboard under Pending Status Checks and never became MRs. Map tag_last_pushed as releaseTimestamp so the age gate can actually pass.

Assisted-by: claude-code/claude-fable-5


___

### **PR Type**
Bug fix


___

### **Description**
- Add `releaseTimestamp` mapping to mkdocs custom datasource

- Add `releaseTimestamp` mapping to zensical custom datasource

- Fixes updates stuck pending due to missing timestamps


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Docker Hub tags API response"] -- "tag_last_pushed" --> B["mkdocs custom datasource releaseTimestamp"]
  A -- "tag_last_pushed" --> C["zensical custom datasource releaseTimestamp"]
  B -- "enables" --> D["minimumReleaseAge check passes"]
  C -- "enables" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mkdocs.json</strong><dd><code>Add releaseTimestamp mapping to Docker Hub datasources</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom/mkdocs.json

<ul><li>Map <code>tag_last_pushed</code> field to <code>releaseTimestamp</code> in mkdocs transform <br>template<br> <li> Map <code>tag_last_pushed</code> field to <code>releaseTimestamp</code> in zensical transform <br>template<br> <li> Fixes releases being stuck as pending due to missing timestamps under <br><code>minimumReleaseAgeBehaviour=timestamp-required</code></ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/renovatebot-default-configuration/pull/16/files#diff-254e5f8894dacf2ea82ea29c2bc509ea76fdb8e06e52cb41f2d1146f672b7a67">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

